### PR TITLE
Add docs for product create and update endpoints

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,7 @@ github_username:  jekyll
 # Build settings
 markdown: kramdown
 theme: minima
+
+collections:
+  types:
+    output: true

--- a/_posts/2016-08-05-sellect-api-v1-documentation.markdown
+++ b/_posts/2016-08-05-sellect-api-v1-documentation.markdown
@@ -586,6 +586,146 @@ $ curl https://some-online-store.com/sellect/v1/products \
 }
 ```
 
+### Create a product
+Creates a new product and returns the result.
+
+|parameter|type|explanation|default|required|
+|---|---|---|---|---|
+|product|[Product](/types/product)|product object|N/A|yes|
+
+**Definition**
+
+```
+POST https://some-online-store.com/sellect/v1/products
+```
+
+**Example Request**
+
+```
+$ curl https://some-online-store.com/sellect/v1/products \
+   -u sellect_test_4gh8KKUIcCEOkCRKQQNOFAiK: \
+   -H "Content-Type: application/json" \
+   -d @- << EOF
+  {
+    "product": {
+      "name": "New Product",
+      "sku": "SOMESKU",
+      "variants_attributes": [
+        {
+          "upc": "12345",
+          "description": "This is the first variant",
+          "pricings_attributes": [
+            {
+              "currency": "USD",
+              "price": "69.67"
+            }
+          ]
+        },
+        {
+          "upc": "123456",
+          "description": "This is another variant",
+          "color": "red",
+          "pricings_attributes": [
+            {
+              "currency": "USD",
+              "price": "42.00"
+            }
+          ]
+        }
+      ],
+      "images_attributes": [
+        {
+          "color": "red",
+          "attachment_remote_url": "https://example.com/images/123456.jpeg"
+        }
+      ]
+    }
+  }
+EOF
+
+```
+
+**Example Response**
+
+```json
+{
+  "sellect/product": {
+    "name": "New Product",
+    "description": null,
+    "variants": [
+      {
+        "upc": "12345",
+        "product_id": 1,
+        "size": null,
+        "color": null
+      },
+      {
+        "upc": "123456",
+        "product_id": 1,
+        "size": null,
+        "color": "red"
+      }
+    ]
+  }
+}
+```
+
+### Update a product
+Update an existing product. Note that nested resources will be updated if an id
+is specified, otherwise a new one will be created.
+
+|parameter|type|explanation|default|required|
+|---|---|---|---|---|
+|product|[Product](/types/product)|product object|N/A|yes|
+
+**Definition**
+
+```
+PUT https://some-online-store.com/sellect/v1/products/{PRODUCT_ID}
+```
+
+**Example Request**
+
+```
+$ curl https://some-online-store.com/sellect/v1/products/1 \
+   -u sellect_test_4gh8KKUIcCEOkCRKQQNOFAiK: \
+   -X PUT \
+   -H "Content-Type: application/json" \
+   -d @- << EOF
+  {
+    "product": {
+      "variants_attributes": [
+        {
+          "id": 1,
+          "description": "Updated variant description"
+        }
+      ]
+    }
+  }
+EOF
+
+```
+
+**Example Response**
+
+```json
+{
+  "sellect/product": {
+    "name": "Some Product",
+    "description": null,
+    "variants": [
+      {
+        "upc": "12345",
+        "product_id": 1,
+        "size": null,
+        "color": null
+      }
+    ]
+  }
+}
+```
+
+
 ## Variants
 
 ### Retrieve a variant

--- a/_types/image.markdown
+++ b/_types/image.markdown
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  Image
+---
+
+An image asset to display for a product.
+
+|parameter|type|explanation|default|required|
+|---|---|---|---|---|
+|position|integer|images are sorted in ascending order based on this field|N/A|no|
+|color|string|the color this image should be displayed for|N/A|yes|
+|alt|string|alt text|N/A|no|
+|attachment_remote_url|string|URL of image file|N/A|if attachment_dropbox_filename is not specified|
+|attachment_dropbox_filename|string|filename of image in configured DropBox images folder|N/A|if attachment_remote_url is not specified|

--- a/_types/pricing.markdown
+++ b/_types/pricing.markdown
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  Pricing
+---
+
+Price for a variant.
+
+|parameter|type|explanation|default|required|
+|---|---|---|---|---|
+|currency|string|currency code for price|N/A|yes|
+|price|decimal|normal variant price|N/A|yes|
+|sale_price|decimal|variant sale price|N/A|no|

--- a/_types/product.markdown
+++ b/_types/product.markdown
@@ -1,0 +1,24 @@
+---
+layout: post
+title:  Pricing
+---
+
+A product
+
+|parameter|type|explanation|default|required|
+|---|---|---|---|---|
+|name|string|product name|N/A|yes|
+|sku|product SKU|string|N/A|yes|
+|permalink|string|unique permalink for product URL|auto-generated from product name|no|
+|season_id|integer|season ID|N/A|no|
+|auto_unpublish|boolean|automatically unpublish when inventory reaches 0|false|no|
+|description|string|product description|N/A|no|
+|detail_description|string|additional description|N/A|no|
+|product_details|string|details for product|N/A|no|
+|product_care|string|product care instructions|N/A|no|
+|product_sizing|string|sizing details|N/A|no|
+|preorder|allow product preorder|boolean|false|no|
+|preorder_date|expected ship date for preorder|date|N/A|no|
+|inventory_threshold|integer|threshold above which the product is considered in stock|N/A|no|
+|images_attributes|[Image[]](/types/image)|array of image objects|N/A|no|
+|variants_attributes|[Variant[]](/types/variant)|array of product variant objects|N/A|no|

--- a/_types/variant.markdown
+++ b/_types/variant.markdown
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  Variant
+---
+
+A product variant.
+
+|parameter|type|explanation|default|required|
+|---|---|---|---|---|
+|upc|string|universal product code|N/A|yes|
+|description|string|description of variant|N/A|no|
+|details|string|details about variant|N/A|no|
+|gm_merchandisable|boolean|whether this variant should appear in the Google Merchant feed|false|no|
+|on_sale|boolean|if variant is on sale|false|no|
+|out_of_stock|boolean|variant is out of stock (manual inventory only)|false|no|
+|preorder_date|date|expected ship date for preorders|N/A|no|
+|published|boolean|whether variant should appear on website|true|no|
+|color|string|color of variant|N/A|no|
+|size|string|size of variant|N/A|no|
+|pricings_attributes|[Pricing[]](/types/pricing)|array of price objects|N/A|no|


### PR DESCRIPTION
Add documentation for new product endpoints. Also add new "types" collection for storing attribute info in a linkable fashion.

Note that some of the descriptions aren't particularly informative since I wasn't sure myself what they did.
For example, it isn't entirely clear to me what the differences between the various "description/details" fields are.

Issue https://github.com/sellect/sellect/issues/2043