### PR TITLE
Make links for types relative

### DIFF
--- a/_includes/product_attributes.markdown
+++ b/_includes/product_attributes.markdown
@@ -1,10 +1,3 @@
----
-layout: post
-title:  Pricing
----
-
-A product
-
 |parameter|type|explanation|default|required|
 |---|---|---|---|---|
 |name|string|product name|N/A|yes|
@@ -20,5 +13,5 @@ A product
 |preorder|allow product preorder|boolean|false|no|
 |preorder_date|expected ship date for preorder|date|N/A|no|
 |inventory_threshold|integer|threshold above which the product is considered in stock|N/A|no|
-|images_attributes|[Image[]](/types/image)|array of image objects|N/A|no|
-|variants_attributes|[Variant[]](/types/variant)|array of product variant objects|N/A|no|
+|images_attributes|[Image[]](types/image)|array of image objects|N/A|no|
+|variants_attributes|[Variant[]](types/variant)|array of product variant objects|N/A|no|

--- a/_posts/2016-08-05-sellect-api-v1-documentation.markdown
+++ b/_posts/2016-08-05-sellect-api-v1-documentation.markdown
@@ -589,9 +589,7 @@ $ curl https://some-online-store.com/sellect/v1/products \
 ### Create a product
 Creates a new product and returns the result.
 
-|parameter|type|explanation|default|required|
-|---|---|---|---|---|
-|product|[Product](/types/product)|product object|N/A|yes|
+{% include product_attributes.markdown %}
 
 **Definition**
 
@@ -674,9 +672,7 @@ EOF
 Update an existing product. Note that nested resources will be updated if an id
 is specified, otherwise a new one will be created.
 
-|parameter|type|explanation|default|required|
-|---|---|---|---|---|
-|product|[Product](/types/product)|product object|N/A|yes|
+{% include product_attributes.markdown %}
 
 **Definition**
 

--- a/_types/variant.markdown
+++ b/_types/variant.markdown
@@ -17,4 +17,4 @@ A product variant.
 |published|boolean|whether variant should appear on website|true|no|
 |color|string|color of variant|N/A|no|
 |size|string|size of variant|N/A|no|
-|pricings_attributes|[Pricing[]](/types/pricing)|array of price objects|N/A|no|
+|pricings_attributes|[Pricing[]](pricing)|array of price objects|N/A|no|


### PR DESCRIPTION
Use relative links so the site still works in a subdirectory. Also in-line the product type.

Clean up for work in https://github.com/sellect/api-docs/pull/1